### PR TITLE
asserts removed from libtess.cat.js; new compile target libtess.debug.js added

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "files": [
     "libtess.min.js",
     "libtess.cat.js",
+    "libtess.debug.js",
     "LICENSE"
   ],
   "scripts": {
@@ -51,10 +52,14 @@
     "gulp-jscs": "^1.2.0",
     "gulp-jshint": "^1.8.5",
     "gulp-mocha": "^1.1.2",
+    "gulp-rename": "^1.2.0",
     "gulp-replace": "^0.4.0",
     "jshint-stylish": "^1.0.0",
     "mocha": "^1.21.5",
     "rfolderify": "^1.3.0",
+    "rocambole": "^0.3.6",
+    "rocambole-token": "^1.2.1",
+    "vinyl-map": "^1.0.1",
     "vinyl-source-stream": "^1.0.0"
   }
 }

--- a/src/sweep.js
+++ b/src/sweep.js
@@ -1375,6 +1375,9 @@ libtess.sweep.initEdgeDict_ = function(tess) {
  * @param {libtess.GluTesselator} tess [description].
  */
 libtess.sweep.doneEdgeDict_ = function(tess) {
+  // NOTE(bckenny): fixedEdges is only used in the assert below, so ignore so
+  // when asserts are removed jshint won't error.
+  /* jshint unused:false */
   var fixedEdges = 0;
 
   var reg;

--- a/test/browser/expectations-viewer-browserified.js
+++ b/test/browser/expectations-viewer-browserified.js
@@ -354,11 +354,11 @@ var chai = require('chai');
 var assert = chai.assert;
 
 // TODO(bckenny): not sure of a better way of doing this yet. Want to inject
-// libtess.cat.js for coverage, but libtess.min.js for all other runs.
+// libtess.debug.js for coverage, but libtess.min.js for all other runs.
 // gulp-mocha takes file names, though. Write to temp files first?
 exports.libtess = (function() {
   if ("browserify" === 'coverage') {
-    return require('../libtess.cat.js');
+    return require('../libtess.debug.js');
 
   } else {
     return require('../libtess.min.js');
@@ -632,7 +632,7 @@ exports.createPlaneRotation = function(normal) {
   })(transform);
 };
 
-},{"../libtess.cat.js":undefined,"../libtess.min.js":undefined,"chai":undefined}],4:[function(require,module,exports){
+},{"../libtess.debug.js":undefined,"../libtess.min.js":undefined,"chai":undefined}],4:[function(require,module,exports){
 /*
 
  Copyright 2000, Silicon Graphics, Inc. All Rights Reserved.

--- a/test/browser/tests-browserified.js
+++ b/test/browser/tests-browserified.js
@@ -698,11 +698,11 @@ var chai = require('chai');
 var assert = chai.assert;
 
 // TODO(bckenny): not sure of a better way of doing this yet. Want to inject
-// libtess.cat.js for coverage, but libtess.min.js for all other runs.
+// libtess.debug.js for coverage, but libtess.min.js for all other runs.
 // gulp-mocha takes file names, though. Write to temp files first?
 exports.libtess = (function() {
   if ("browserify" === 'coverage') {
-    return require('../libtess.cat.js');
+    return require('../libtess.debug.js');
 
   } else {
     return require('../libtess.min.js');
@@ -976,7 +976,7 @@ exports.createPlaneRotation = function(normal) {
   })(transform);
 };
 
-},{"../libtess.cat.js":undefined,"../libtess.min.js":undefined,"chai":undefined}],6:[function(require,module,exports){
+},{"../libtess.debug.js":undefined,"../libtess.min.js":undefined,"chai":undefined}],6:[function(require,module,exports){
 /*
 
  Copyright 2000, Silicon Graphics, Inc. All Rights Reserved.

--- a/test/common.js
+++ b/test/common.js
@@ -5,11 +5,11 @@ var chai = require('chai');
 var assert = chai.assert;
 
 // TODO(bckenny): not sure of a better way of doing this yet. Want to inject
-// libtess.cat.js for coverage, but libtess.min.js for all other runs.
+// libtess.debug.js for coverage, but libtess.min.js for all other runs.
 // gulp-mocha takes file names, though. Write to temp files first?
 exports.libtess = (function() {
   if (process.env.testType === 'coverage') {
-    return require('../libtess.cat.js');
+    return require('../libtess.debug.js');
 
   } else {
     return require('../libtess.min.js');


### PR DESCRIPTION
when executing `libtess.cat.js`, `libtess.assert` statements were throwing off JS engines wrt inlining, etc. `assert`s are now removed from `libtess.cat.js` and a new compilation target, `libtess.debug.js` added which still includes them.
